### PR TITLE
Update formula to v1.0.7-beta.6

### DIFF
--- a/flutter_bunny.rb
+++ b/flutter_bunny.rb
@@ -2,16 +2,16 @@ class FlutterBunny < Formula
   desc "Flutter Bunny: A CLI tool for Flutter development"
   homepage "https://github.com/demola234/flutter_bunny_cli"
   license "MIT"
-  version "1.0.7-beta.3"
+  version "1.0.7-beta.6"
 
   on_macos do
     on_arm do
-      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.3.tar.gz"
-      sha256 "e92c9fde082ac1807a0ed96c59601bf39b4913af2783050d903f77be180ccaf1"
+      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.6.tar.gz"
+      sha256 "18927449644b618379f96d0bb09cc9a8d1c22689fc5be804c38111fa134ab498"
     end
     on_intel do
-      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.3.tar.gz"
-      sha256 "e92c9fde082ac1807a0ed96c59601bf39b4913af2783050d903f77be180ccaf1"
+      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.6.tar.gz"
+      sha256 "18927449644b618379f96d0bb09cc9a8d1c22689fc5be804c38111fa134ab498"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula to version v1.0.7-beta.6.
Created automatically by GitHub Actions.