### PR TITLE
Update formula to v1.0.7-beta.7

### DIFF
--- a/flutter_bunny.rb
+++ b/flutter_bunny.rb
@@ -2,16 +2,16 @@ class FlutterBunny < Formula
   desc "Flutter Bunny: A CLI tool for Flutter development"
   homepage "https://github.com/demola234/flutter_bunny_cli"
   license "MIT"
-  version "1.0.7-beta.6"
+  version "1.0.7-beta.7"
 
   on_macos do
     on_arm do
-      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.6.tar.gz"
-      sha256 "18927449644b618379f96d0bb09cc9a8d1c22689fc5be804c38111fa134ab498"
+      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.7.tar.gz"
+      sha256 "8c90b3545bd1caa73940be7b8975583cd86ca246a52ddf83e70de1f5a7a89a9d"
     end
     on_intel do
-      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.6.tar.gz"
-      sha256 "18927449644b618379f96d0bb09cc9a8d1c22689fc5be804c38111fa134ab498"
+      url "https://github.com/demola234/flutter_bunny_cli/archive/refs/tags/v1.0.7-beta.7.tar.gz"
+      sha256 "8c90b3545bd1caa73940be7b8975583cd86ca246a52ddf83e70de1f5a7a89a9d"
     end
   end
 


### PR DESCRIPTION
This PR updates the Homebrew formula to version v1.0.7-beta.7.
Created automatically by GitHub Actions.